### PR TITLE
feat: add `ClientId::Paladin`

### DIFF
--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -19,6 +19,7 @@ enum ClientId {
     JitoLabs,
     Firedancer,
     Agave,
+    Paladin,
     // If new variants are added, update From<u16> and TryFrom<ClientId>.
     Unknown(u16),
 }
@@ -79,7 +80,7 @@ impl Default for Version {
             commit: compute_commit(option_env!("CI_COMMIT")).unwrap_or_default(),
             feature_set,
             // Other client implementations need to modify this line.
-            client: u16::try_from(ClientId::JitoLabs).unwrap(),
+            client: u16::try_from(ClientId::Paladin).unwrap(),
         }
     }
 }
@@ -114,6 +115,7 @@ impl From<u16> for ClientId {
             1u16 => Self::JitoLabs,
             2u16 => Self::Firedancer,
             3u16 => Self::Agave,
+            4u16 => Self::Paladin,
             _ => Self::Unknown(client),
         }
     }
@@ -128,6 +130,7 @@ impl TryFrom<ClientId> for u16 {
             ClientId::JitoLabs => Ok(1u16),
             ClientId::Firedancer => Ok(2u16),
             ClientId::Agave => Ok(3u16),
+            ClientId::Paladin => Ok(4u16),
             ClientId::Unknown(client @ 0u16..=3u16) => Err(format!("Invalid client: {client}")),
             ClientId::Unknown(client) => Ok(client),
         }


### PR DESCRIPTION
#### Summary of Changes

agave-validator -version shows that it runs paladin