### PR TITLE
Multi Block Engine #PAL-156

### DIFF
--- a/core/src/proxy/block_engine_stage.rs
+++ b/core/src/proxy/block_engine_stage.rs
@@ -109,13 +109,8 @@ impl BlockEngineStage {
             .chain(secondary_urls.into_iter().map(Either::Right))
             .enumerate()
             .map(|(index, config)| {
-                let thread_name = match &config {
-                    Either::Left(_) => "block-engine-primary".to_string(),
-                    Either::Right(_) => format!("block-engine-secondary-{}", index),
-                };
-
                 Self::spawn_block_engine_thread(
-                    thread_name,
+                    format!("block-engine-{}", index),
                     config,
                     cluster_info.clone(),
                     bundle_tx.clone(),
@@ -142,19 +137,8 @@ impl BlockEngineStage {
         block_builder_fee_info: Arc<Mutex<BlockBuilderFeeInfo>>,
     ) -> JoinHandle<()>{
         Builder::new().name(thread_name).spawn(move ||{
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap();
-            rt.block_on(Self::start(
-                config,
-                cluster_info,
-                bundle_tx,
-                packet_tx,
-                banking_packet_sender,
-                exit,
-                block_builder_fee_info,
-            ));
+            let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
+            rt.block_on(Self::start(config, cluster_info, bundle_tx, packet_tx, banking_packet_sender, exit, block_builder_fee_info));
         }).unwrap()
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -157,6 +157,7 @@ impl Tpu {
         enable_block_production_forwarding: bool,
         _generator_config: Option<GeneratorConfig>, /* vestigial code for replay invalidator */
         block_engine_config: Arc<Mutex<BlockEngineConfig>>,
+        secondary_block_engine_urls: Vec<String>,
         relayer_config: Arc<Mutex<RelayerConfig>>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         tip_manager_config: TipManagerConfig,
@@ -288,6 +289,7 @@ impl Tpu {
         let (bundle_sender, bundle_receiver) = unbounded();
         let block_engine_stage = BlockEngineStage::new(
             block_engine_config,
+            secondary_block_engine_urls,
             bundle_sender,
             cluster_info.clone(),
             packet_sender.clone(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -326,6 +326,7 @@ pub struct ValidatorConfig {
     // jito configuration
     pub relayer_config: Arc<Mutex<RelayerConfig>>,
     pub block_engine_config: Arc<Mutex<BlockEngineConfig>>,
+    pub secondary_block_engine_urls: Vec<String>,
     pub shred_receiver_address: Arc<RwLock<Option<SocketAddr>>>,
     pub shred_retransmit_receiver_address: Arc<RwLock<Option<SocketAddr>>>,
     pub tip_manager_config: TipManagerConfig,
@@ -408,6 +409,7 @@ impl Default for ValidatorConfig {
             delay_leader_block_for_pending_fork: false,
             relayer_config: Arc::new(Mutex::new(RelayerConfig::default())),
             block_engine_config: Arc::new(Mutex::new(BlockEngineConfig::default())),
+            secondary_block_engine_urls: vec![],
             shred_receiver_address: Arc::new(RwLock::new(None)),
             shred_retransmit_receiver_address: Arc::new(RwLock::new(None)),
             tip_manager_config: TipManagerConfig::default(),
@@ -1645,6 +1647,7 @@ impl Validator {
             config.enable_block_production_forwarding,
             config.generator_config.clone(),
             config.block_engine_config.clone(),
+            config.secondary_block_engine_urls.clone(),
             config.relayer_config.clone(),
             leader_schedule_cache.clone(),
             config.tip_manager_config.clone(),

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -76,6 +76,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
         relayer_config: config.relayer_config.clone(),
         block_engine_config: config.block_engine_config.clone(),
+        secondary_block_engine_urls: config.secondary_block_engine_urls.clone(),
         shred_receiver_address: config.shred_receiver_address.clone(),
         shred_retransmit_receiver_address: config.shred_retransmit_receiver_address.clone(),
         tip_manager_config: config.tip_manager_config.clone(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -13,7 +13,6 @@ use {
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         consensus::{tower_storage::TowerStorage, Tower},
         proxy::{
-            block_engine_stage::{BlockEngineConfig, BlockEngineStage},
             relayer_stage::{RelayerConfig, RelayerStage},
         },
         repair::repair_service,
@@ -485,22 +484,12 @@ impl AdminRpc for AdminRpcImpl {
         block_engine_url: String,
         trust_packets: bool,
     ) -> Result<()> {
-        debug!("set_block_engine_config request received");
-        let config = BlockEngineConfig {
-            block_engine_url,
-            trust_packets,
-        };
-        // Detailed log messages are printed inside validate function
-        if BlockEngineStage::is_valid_block_engine_config(&config) {
-            meta.with_post_init(|post_init| {
-                *post_init.block_engine_config.lock().unwrap() = config;
-                Ok(())
-            })
-        } else {
-            Err(jsonrpc_core::error::Error::invalid_params(
-                "failed to set block engine config. see logs for details.",
-            ))
-        }
+        meta.with_post_init(|post_init|{
+            let mut config = post_init.block_engine_config.lock().unwrap();
+            config.block_engine_url = block_engine_url;
+            config.trust_packets = trust_packets;
+            Ok(())
+        })
     }
 
     fn set_identity(
@@ -998,8 +987,7 @@ mod tests {
             accounts_index::AccountSecondaryIndexes,
         },
         solana_core::{
-            consensus::tower_storage::NullTowerStorage,
-            validator::{Validator, ValidatorConfig, ValidatorTpuConfig},
+            consensus::tower_storage::NullTowerStorage, proxy::block_engine_stage::BlockEngineConfig, validator::{Validator, ValidatorConfig, ValidatorTpuConfig}
         },
         solana_gossip::cluster_info::{ClusterInfo, Node},
         solana_inline_spl::token,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1740,6 +1740,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
         )
         .arg(
+            Arg::with_name("secondary_block_engines")
+            .long("secondary-block-engines")
+            .help("Additional block engine URLs (packets from these will not be trusted)")
+            .takes_value(true)
+            .multiple(true)
+        )
+        .arg(
             Arg::with_name("trust_relayer_packets")
                 .long("trust-relayer-packets")
                 .takes_value(false)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -820,10 +820,16 @@ pub fn main() {
         } else {
             "".to_string()
         },
-        secondary_block_engine_urls: matches.values_of("secondary_block_engine_urls").
-            map(|urls| urls.map(String::from).collect()).
-            unwrap_or_default(),
         trust_packets: matches.is_present("trust_block_engine_packets"),
+    };
+
+    let secondary_block_engine_urls = if matches.is_present("secondary_block_engines") {
+        values_t_or_exit!(matches, "secondary_block_engines", String)
+            .into_iter()
+            .map(|url| url.to_string())
+            .collect()
+    } else {
+        Vec::new()
     };
 
     // Defaults are set in cli definition, safe to use unwrap() here
@@ -1019,6 +1025,7 @@ pub fn main() {
         wen_restart_coordinator: value_t!(matches, "wen_restart_coordinator", Pubkey).ok(),
         relayer_config: Arc::new(Mutex::new(relayer_config)),
         block_engine_config: Arc::new(Mutex::new(block_engine_config)),
+        secondary_block_engine_urls,
         tip_manager_config,
         shred_receiver_address: Arc::new(RwLock::new(
             matches

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -820,6 +820,9 @@ pub fn main() {
         } else {
             "".to_string()
         },
+        secondary_block_engine_urls: matches.values_of("secondary_block_engine_urls").
+            map(|urls| urls.map(String::from).collect()).
+            unwrap_or_default(),
         trust_packets: matches.is_present("trust_block_engine_packets"),
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -826,6 +826,7 @@ pub fn main() {
     let secondary_block_engine_urls = if matches.is_present("secondary_block_engines") {
         values_t_or_exit!(matches, "secondary_block_engines", String)
             .into_iter()
+            .filter(|url| !url.is_empty())
             .map(|url| url.to_string())
             .collect()
     } else {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -826,7 +826,7 @@ pub fn main() {
     let secondary_block_engine_urls = if matches.is_present("secondary_block_engines") {
         values_t_or_exit!(matches, "secondary_block_engines", String)
             .into_iter()
-            .filter(|url| !url.is_empty())
+            .inspect(|url| assert!(!url.is_empty(), "Invalid block engine URL: {url}"))
             .map(|url| url.to_string())
             .collect()
     } else {


### PR DESCRIPTION
#### Problem
Currently, the Jito block engine stage (https://github.com/jito-foundation/jito-solana/blob/master/core/src/proxy/block_engine_stage.rs) connects to a single block engine. Our goal is to support an array of block engines. 

#### Summary of Changes
- Spawn the primary block engine connection BlockEngine::start. This should be the first block engine URL/config.
- Spawn any additional block engine connections [1..] of the vector of block engines.

###### Primary Block Engine (mutable at runtime through admin_rpc)
- Will fetch & write block_builder_fee_info globally. 
- Will connect to block engine.

###### Secondary block engines (multiple) (immutable after setup)
- Will only read block_builder_fee_info.
- Will connect to block engine.
- Will forward packets

<!-- Fixes #-->
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
