### PR TITLE
Secondary BE urls arg

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1782,6 +1782,17 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
     )
     .arg(
+        Arg::with_name("secondary_block_engines_urls")
+            .long("secondary-block-engines-urls")
+            .value_name("HOST:PORT")
+            .help(
+                "Specify extra block engines urls to receive bundles from. \
+                Comma separated urls, May be specified multiple times.",
+            )
+            .takes_value(true)
+            .multiple(true)
+    )
+    .arg(
         Arg::with_name("batch_interval_ms")
             .long("batch-interval-ms")
             .help("scheduler batch interval in milliseconds. Defaults to 50ms")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -856,6 +856,11 @@ pub fn execute(
             Ipv4Addr::UNSPECIFIED,
             value_of(matches, "p3_mev_port").unwrap(),
         )),
+        secondary_block_engine_urls: matches
+            .values_of("secondary_block_engines_urls")
+            .unwrap_or_default()
+            .map(|v| v.to_string())
+            .collect(),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
Adds new argument to validator that takes the secondary block engines urls
