### PR TITLE
Secondary BE urls arg (#51)

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -139,6 +139,7 @@ pub struct TestValidatorGenesis {
     admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
     pub block_engine_url: String,
     pub relayer_url: String,
+    pub secondary_block_engine_urls: Vec<String> 
 }
 
 impl Default for TestValidatorGenesis {
@@ -174,6 +175,7 @@ impl Default for TestValidatorGenesis {
                 Arc::<RwLock<Option<AdminRpcRequestMetadataPostInit>>>::default(),
             block_engine_url: String::default(),
             relayer_url: String::default(),
+            secondary_block_engine_urls: vec![]
         }
     }
 }
@@ -1092,6 +1094,7 @@ impl TestValidator {
                 oldest_allowed_heartbeat: DEFAULT_RELAYER_EXPECTED_HEARTBEAT_INTERVAL * 3,
                 trust_packets: false,
             })),
+            secondary_block_engine_urls: config.secondary_block_engine_urls.clone(),
             ..ValidatorConfig::default_for_test()
         };
         if let Some(ref tower_storage) = config.tower_storage {

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -594,6 +594,11 @@ fn main() {
         .value_of("relayer_url")
         .map(ToString::to_string)
         .unwrap_or_default();
+    genesis.secondary_block_engine_urls = matches
+        .values_of("secondary_block_engines_urls")
+        .unwrap_or_default()
+        .map(ToString::to_string)
+        .collect();
 
     match genesis.start_with_mint_address_and_geyser_plugin_rpc(
         mint_address,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1077,6 +1077,17 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .help("Relayer url. Set to empty string to disable relayer connection.")
                 .takes_value(true),
         )
+        .arg(
+        Arg::with_name("secondary_block_engines_urls")
+            .long("secondary-block-engines-urls")
+            .value_name("HOST:PORT")
+            .help(
+                "Specify extra block engines urls to receive bundles from. \
+                Comma separated urls, May be specified multiple times.",
+            )
+            .takes_value(true)
+            .multiple(true)
+    )
 }
 
 pub struct DefaultTestArgs {

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1782,6 +1782,17 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
     )
     .arg(
+        Arg::with_name("secondary_block_engines_urls")
+            .long("secondary-block-engines-urls")
+            .value_name("HOST:PORT")
+            .help(
+                "Specify extra block engines urls to receive bundles from. \
+                Comma separated urls, May be specified multiple times.",
+            )
+            .takes_value(true)
+            .multiple(true)
+    )
+    .arg(
         Arg::with_name("batch_interval_ms")
             .long("batch-interval-ms")
             .help("scheduler batch interval in milliseconds. Defaults to 50ms")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -856,6 +856,11 @@ pub fn execute(
             Ipv4Addr::UNSPECIFIED,
             value_of(matches, "p3_mev_port").unwrap(),
         )),
+        secondary_block_engine_urls: matches
+            .values_of("secondary_block_engines_urls")
+            .unwrap_or_default()
+            .map(ToString::to_string)
+            .collect(),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
* add secondary block engines urls as argument when starting validator

* added secondary BE urls to test validator